### PR TITLE
Fix for #20 - color transition now returns correct state

### DIFF
--- a/Arilux.cpp
+++ b/Arilux.cpp
@@ -135,10 +135,23 @@ uint8_t Arilux::setAll(uint8_t p_red, uint8_t p_green, uint8_t p_blue, uint8_t p
 uint8_t Arilux::setColor(uint8_t p_red, uint8_t p_green, uint8_t p_blue) {
   return setAll(p_red, p_green, p_blue, getWhite1Value(), getWhite2Value(), true);
 }
+
+uint8_t Arilux::setFadeToColor(uint8_t p_red, uint8_t p_green, uint8_t p_blue) {
+    m_color.red = p_red;
+    m_color.green = p_green;
+    m_color.blue = p_blue;
+}
+
+uint8_t Arilux::setFadeColor(uint8_t p_red, uint8_t p_green, uint8_t p_blue) {
+  if (!m_state) {
+    m_state = true;
+  }
+  return setAll(p_red, p_green, p_blue, getWhite1Value(), getWhite2Value(), false);
+}
+
 uint8_t Arilux::setWhite(uint8_t p_white1, uint8_t p_white2) {
   return setAll(getRedValue(), getGreenValue(), getBlueValue(), p_white1, p_white2, true);
 }
-
 
 uint8_t Arilux::setAll(uint8_t p_red, uint8_t p_green, uint8_t p_blue, uint8_t p_white1, uint8_t p_white2, uint8_t p_retain) {
   if ((p_red < 0 || p_red > ARILUX_PWM_RANGE) || (p_green < 0 || p_green > ARILUX_PWM_RANGE) || (p_blue < 0 || p_blue > ARILUX_PWM_RANGE || p_white1 < 0 || p_white1 > ARILUX_PWM_RANGE || p_white2 < 0 || p_white2 > ARILUX_PWM_RANGE))

--- a/Arilux.h
+++ b/Arilux.h
@@ -159,6 +159,8 @@ class Arilux {
     char * getColorString(void);
 
     uint8_t setColor(uint8_t p_red, uint8_t p_green, uint8_t p_blue);
+    uint8_t setFadeColor(uint8_t p_red, uint8_t p_green, uint8_t p_blue);
+    uint8_t setFadeToColor(uint8_t p_red, uint8_t p_green, uint8_t p_blue);
     uint8_t setAll(uint8_t p_red, uint8_t p_green, uint8_t p_blue, uint8_t p_white1, uint8_t p_white2);
     uint8_t setWhite(uint8_t p_white1, uint8_t p_white2);
     uint8_t setState(uint8_t p_state);

--- a/Arilux_AL-LC0X.ino
+++ b/Arilux_AL-LC0X.ino
@@ -323,7 +323,8 @@ void handleEffects(void) {
       stepR = calculateStep(redVal, realRed);
       stepG = calculateStep(grnVal, realGreen);
       stepB = calculateStep(bluVal, realBlue);
-
+      arilux.setFadeToColor(realRed, realGreen, realBlue);
+      
       inFade = true;
     }
   }
@@ -339,7 +340,7 @@ void handleEffects(void) {
         grnVal = calculateVal(stepG, grnVal, loopCount);
         bluVal = calculateVal(stepB, bluVal, loopCount);
 
-        arilux.setColor(redVal, grnVal, bluVal); // Write current values to LED pins
+        arilux.setFadeColor(redVal, grnVal, bluVal); // Write current values to LED pins
 
         DEBUG_PRINT("Fade Loop count: ");
         DEBUG_PRINTLN(loopCount);


### PR DESCRIPTION
Fixing issue #20. Setting a transition in the color command now returns the correct end state to MQTT.